### PR TITLE
gemspec: Drop defunct property rubyforge_project

### DIFF
--- a/sendfile.gemspec
+++ b/sendfile.gemspec
@@ -12,11 +12,9 @@ EOF
 	gs.author = 'Toby DiPasquale'
 	gs.email = 'toby@cbcg.net'
 	gs.homepage = 'https://github.com/codeslinger/sendfile'
-	gs.rubyforge_project = 'ruby-sendfile'
 	gs.files = File.read('FILES').split($/)
 	gs.test_files = Dir.glob 'test/test_*.rb'
 	gs.extensions << 'ext/extconf.rb'
-	gs.has_rdoc = true
 	gs.extra_rdoc_files = %w(README.textile)
 	gs.required_ruby_version = '>= 1.8.0'
 end


### PR DESCRIPTION
The RubyGems gemspec property `rubyforge_project` has been removed without a replacement. This PR removes that property. (Also dropped has_rdoc for same reason)

## Background

* [RubyForge was closed down in 2013][1].
* [rubygems/rubygems#2436 deprecated the `rubyforge_project` property][2].

[1]: https://twitter.com/evanphx/status/399552820380053505
[2]: rubygems/rubygems#2436

